### PR TITLE
Remove print statement from fetch method

### DIFF
--- a/semantics3/semantics3.py
+++ b/semantics3/semantics3.py
@@ -45,7 +45,6 @@ class Semantics3Request:
                     params = params,
                     headers={'User-Agent':'Semantics3 Python Lib/0.2'}
                   )
-        print(content)
         return content
 
     def remove(self, endpoint, *fields):


### PR DESCRIPTION
This print statement was introduced in https://github.com/Semantics3/semantics3-python/commit/226bb3782a0b5218d75035f2c334ac91ebb602c9 and it seems like it was an accident, a debugging print statement that got committed. This PR removes it.